### PR TITLE
use `&Path` as input path parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 /Cargo.lock
 
+# IDE
+.idea/
 .vs/
 dotnet-sandbox/obj/
 dotnet-sandbox/bin/

--- a/csbindgen/src/alias_map.rs
+++ b/csbindgen/src/alias_map.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use crate::type_meta::{RustType, TypeKind};
 
@@ -42,9 +42,9 @@ impl AliasMap {
         match self.type_aliases.get(name) {
             Some(x) => {
                 let d = self.normalize_deep(x);
-                 (d.type_name.clone(), Some(d))
+                (d.type_name.clone(), Some(d))
             }
-            None => (name.to_owned(), None)
+            None => (name.to_owned(), None),
         }
     }
 

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -232,6 +232,10 @@ impl Builder {
 }
 
 fn make_file<P: AsRef<Path>>(path: P) -> io::Result<File> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let file = OpenOptions::new()
         .write(true)
         .truncate(true)

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{
     error::Error,
     fs::{File, OpenOptions},
@@ -12,8 +13,8 @@ pub struct Builder {
 }
 
 pub struct BindgenOptions {
-    pub input_bindgen_file: String,
-    pub input_extern_files: Vec<String>,
+    pub input_bindgen_file: PathBuf,
+    pub input_extern_files: Vec<PathBuf>,
     pub method_filter: fn(method_name: String) -> bool,
     pub rust_method_type_path: String,
     pub rust_method_prefix: String,
@@ -33,7 +34,7 @@ impl Default for Builder {
     fn default() -> Self {
         Self {
             options: BindgenOptions {
-                input_bindgen_file: "".to_string(),
+                input_bindgen_file: PathBuf::new(),
                 input_extern_files: vec![],
                 method_filter: |x| !x.starts_with('_'),
                 rust_method_type_path: "".to_string(),
@@ -59,16 +60,16 @@ impl Builder {
     }
 
     /// Change an input .rs file(such as generated from bindgen) to generate binding.
-    pub fn input_bindgen_file<T: Into<String>>(mut self, input_bindgen_file: T) -> Builder {
-        self.options.input_bindgen_file = input_bindgen_file.into();
+    pub fn input_bindgen_file<T: AsRef<Path>>(mut self, input_bindgen_file: T) -> Builder {
+        self.options.input_bindgen_file = input_bindgen_file.as_ref().to_path_buf();
         self
     }
 
     /// Add an input .rs file for collect extern methods to C# binding.
-    pub fn input_extern_file<T: Into<String>>(mut self, input_extern_file: T) -> Builder {
+    pub fn input_extern_file<T: AsRef<Path>>(mut self, input_extern_file: T) -> Builder {
         self.options
             .input_extern_files
-            .push(input_extern_file.into());
+            .push(input_extern_file.as_ref().to_path_buf());
         self
     }
 
@@ -165,7 +166,7 @@ impl Builder {
         &self,
         csharp_output_path: P,
     ) -> Result<(), Box<dyn Error>> {
-        if !self.options.input_bindgen_file.is_empty() {
+        if self.has_input_file() {
             let (_, csharp) = generate(GenerateKind::InputBindgen, &self.options)?;
 
             let mut csharp_file = make_file(csharp_output_path.as_ref())?;
@@ -173,7 +174,7 @@ impl Builder {
             csharp_file.flush()?;
         }
 
-        if !self.options.input_extern_files.is_empty() {
+        if self.has_input_externals() {
             let (_, csharp) = generate(GenerateKind::InputExtern, &self.options)?;
 
             let mut csharp_file = make_file(csharp_output_path.as_ref())?;
@@ -184,12 +185,19 @@ impl Builder {
         Ok(())
     }
 
+    fn has_input_file(&self) -> bool {
+        !self.options.input_bindgen_file.to_string_lossy().is_empty()
+    }
+    fn has_input_externals(&self) -> bool {
+        !self.options.input_extern_files.is_empty()
+    }
+
     pub fn generate_to_file<P: AsRef<Path>>(
         &self,
         rust_output_path: P,
         csharp_output_path: P,
     ) -> Result<(), Box<dyn Error>> {
-        if !self.options.input_bindgen_file.is_empty() {
+        if self.has_input_file() {
             let (rust, csharp) = generate(GenerateKind::InputBindgen, &self.options)?;
 
             if let Some(rust) = rust {
@@ -204,7 +212,7 @@ impl Builder {
             csharp_file.flush()?;
         }
 
-        if !self.options.input_extern_files.is_empty() {
+        if self.has_input_externals() {
             let (rust, csharp) = generate(GenerateKind::InputExtern, &self.options)?;
 
             if let Some(rust) = rust {

--- a/csbindgen/src/lib.rs
+++ b/csbindgen/src/lib.rs
@@ -38,7 +38,7 @@ pub(crate) fn generate(
 
     for path in paths {
         let file_content = std::fs::read_to_string(path)
-            .expect(("input file not found, path:".to_string() + path).as_str());
+            .expect(&format!("input file not found, path: {}", path.display()));
         let file_ast = syn::parse_file(file_content.as_str())?;
 
         match generate_kind {

--- a/csbindgen/src/type_meta.rs
+++ b/csbindgen/src/type_meta.rs
@@ -271,13 +271,7 @@ impl RustType {
                     sb.push_str(type_name.as_str());
                 } else {
                     let type_name = type_csharp_string.as_str();
-                    sb.push_str(
-                        format!(
-                            "void/* {}[] */",
-                            type_name
-                        )
-                        .as_str(),
-                    );
+                    sb.push_str(format!("void/* {}[] */", type_name).as_str());
                 }
             }
             TypeKind::Function(parameters, return_type) => {


### PR DESCRIPTION
Should accept `Path` here, or  it unable to use path join:

Fix usage:

```rust
csbindgen::Builder::default().input_extern_file(dir.join("src/bind/lib.rs"))
```