### PR TITLE
Add a setting to GetStarted to build crate into a dynamic library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Getting Started
 Install on `Cargo.toml` as `build-dependencies` and set up `bindgen::Builder` on `build.rs`.
 
 ```toml
+[lib]
+crate-type = ["cdylib"]
+
 [build-dependencies]
 csbindgen = "1.7.0"
 ```


### PR DESCRIPTION
When trying this repository, I had a little trouble because I did not have GetStarted configured to output the crate in dynamic library.

It is a small change, but I think it would be a good annotation for Rustacian.