### PR TITLE
Function pointer parameters now has names

### DIFF
--- a/csbindgen/src/type_meta.rs
+++ b/csbindgen/src/type_meta.rs
@@ -442,7 +442,8 @@ pub fn build_method_delegate_if_required(
 
                 let joined_param = parameters
                     .iter()
-                    .map(|p| {
+                    .enumerate()
+                    .map(|(index, p)| {
                         let cs = p.rust_type.to_csharp_string(
                             options,
                             alias_map,
@@ -450,7 +451,11 @@ pub fn build_method_delegate_if_required(
                             method_name,
                             parameter_name,
                         );
-                        format!("{} {}", cs, escape_name(p.name.as_str()))
+                        // a is ascii for 97
+                        let parameter_name = char::from_u32(index as u32 + 97)
+                            .unwrap_or('?')
+                            .to_string();
+                        format!("{} {}", cs, escape_name(parameter_name.as_str()))
                     })
                     .collect::<Vec<_>>()
                     .join(", ");


### PR DESCRIPTION
- Fixes #39 

Basically function pointers such as `extern "C" fn(i32)`, the parameter doesn't have names.
In order to fix such issue, I used the alphabet to represent order

`escape_name` could be removed and directly put the name there since its just a-z.
although im not sure if it will break something, so i left it there