### PR TITLE
 add byte* point to string marshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ csbindgen::Builder::default()
     .csharp_imported_namespaces("MyLib")    // optional, default: empty
     .csharp_generate_const (false)          // optional, default: false
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
+    .csharp_marshal_byte_point_as_string("") // optional, default: ""
     .generate_csharp_file("../dotnet-sandbox/NativeMethods.cs")     // required
     .unwrap();
 ```
@@ -208,6 +209,8 @@ namespace {csharp_namespace}
 `csharp_disable_emit_dll_name` is optional, if set to true then don't emit `const string __DllName`. It is useful for generate same class-name from different builder.
 
 `csharp_generate_const` is optional, if set to true then generate C# `const` field from Rust `const`.
+
+`csharp_marshal_byte_point_as_string` is optional,default is emputy,it will not work. if set to `LPUTF8Str` or `LPTStr` string,the `byte*` point parameter will be marshal to string like `([MarshalAs(UnmanagedType.LPTStr)]String msg)`. detail marshal type please vist:[UnmanagedType](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.unmanagedtype)
 
 `input_extern_file` and `input_bindgen_file` allow mulitple call, if you need to add dependent struct, use this.
 
@@ -273,6 +276,7 @@ csbindgen::Builder::default()
     .csharp_use_function_pointer(true)            // optional, default: true
     .csharp_imported_namespaces("MyLib")          // optional, default: empty
     .csharp_generate_const (false)                // optional, default: false
+    .csharp_marshal_byte_point_as_string("")      // optional, default: empty
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
     .generate_to_file("src/lz4_ffi.rs", "../dotnet-sandbox/lz4_bindgen.cs") // required
     .unwrap();

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -31,6 +31,7 @@ pub struct BindgenOptions {
     pub csharp_use_function_pointer: bool,
     pub csharp_imported_namespaces: Vec<String>,
     pub csharp_generate_const: bool,
+    pub csharp_marshal_byte_point_as_string:String,
 }
 
 impl Default for Builder {
@@ -55,6 +56,7 @@ impl Default for Builder {
                 csharp_use_function_pointer: true,
                 csharp_imported_namespaces: vec![],
                 csharp_generate_const: false,
+                csharp_marshal_byte_point_as_string:"".to_string(),
             },
         }
     }
@@ -186,6 +188,12 @@ impl Builder {
     /// conifure C# generate const, default is false
     pub fn csharp_generate_const(mut self, csharp_generate_const: bool) -> Builder {
         self.options.csharp_generate_const = csharp_generate_const;
+        self
+    }
+
+     /// configure C# byte* to string marshal (default is ``),can set`LPWStr|LPUTF8Str`
+    pub fn csharp_marshal_byte_point_as_string<T: Into<String>>(mut self,  marshal_string_type:T) -> Builder {
+        self.options.csharp_marshal_byte_point_as_string = marshal_string_type.into();
         self
     }
 

--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -87,6 +87,7 @@ pub fn emit_csharp(
     let class_name = &options.csharp_class_name;
     let method_prefix = &options.csharp_method_prefix;
     let accessibility = &options.csharp_class_accessibility;
+    let string_marshal=&options.csharp_marshal_byte_point_as_string;
 
     let mut dll_name = match options.csharp_if_symbol.as_str() {
         "" => format!(
@@ -172,6 +173,9 @@ pub fn emit_csharp(
                         .to_csharp_string(options, aliases, false, method_name, &p.name);
                 if type_name == "bool" {
                     type_name = "[MarshalAs(UnmanagedType.U1)] bool".to_string();
+                }
+                if type_name=="byte*"&& !string_marshal.is_empty() {
+                    type_name= format!("[MarshalAs(UnmanagedType.{string_marshal})] string").to_string();
                 }
 
                 format!("{} {}", type_name, escape_name(p.name.as_str()))


### PR DESCRIPTION
when i use this great tool.it easily transform the quickjs' c code to  csharp code.
https://github.com/startewho/qsharp.
three are too many byte*
```cs
 public static extern JSValue JS_Eval(JSContext* ctx, byte* input, nuint input_len, byte* filename, int eval_flags);
```
![image](https://github.com/Cysharp/csbindgen/assets/898009/e9fcc20e-5b69-43a7-9b05-7facf02f3ef9)


 that i have to use the use like this
```cs
 fixed (byte* file = filename)
 {
     JSValue val = NativeMethods.JS_Eval(ctx, buffer, (nuint)input.Length, file, 0);
     if (val.tag != 2)
     {
         val = NativeMethods.JS_GetException(ctx);
         var name = GetStringProperty(ctx, val, "name");
         var msg = GetStringProperty(ctx, val, "message");
         var stack = GetStringProperty(ctx, val, "stack");
     }
 }
```
if we add a csharp_marshal_byte_point_as_string option. when i set thing string marshler ,it work like

```cs
 public static extern JSValue JS_Eval(JSContext* ctx, [MarshalAs(UnmanagedType.LPTStr)]String input, nuint input_len, [MarshalAs(UnmanagedType.LPTStr)] filename, int eval_flags);
```
 