### PR TITLE
Non repr attribute struct treat as unit struct

### DIFF
--- a/csbindgen-tests/src/lib.rs
+++ b/csbindgen-tests/src/lib.rs
@@ -606,6 +606,20 @@ pub struct CallbackTable {
     pub foobar: extern "C" fn(i: i32) -> i32,
 }
 
+pub struct InternalHiddenContext {
+    pub a: i32
+}
+
+pub struct TreatAsEmptyStruct {
+    internal: std::sync::Arc<InternalHiddenContext>
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn init_treat_as_empty_struct_context(_out: NonNull<Box<TreatAsEmptyStruct>>) {}
+
+#[no_mangle]
+pub unsafe extern "C" fn free_treat_as_empty_struct_context(_src: *mut TreatAsEmptyStruct) {}
+
 // fn run_physix(){
 //     unsafe {
 //         let foundation = physx_create_foundation();

--- a/dotnet-sandbox/NativeMethods.cs
+++ b/dotnet-sandbox/NativeMethods.cs
@@ -176,6 +176,12 @@ namespace CsBindgen
         [DllImport(__DllName, EntryPoint = "call_bindgen_lz4", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void call_bindgen_lz4();
 
+        [DllImport(__DllName, EntryPoint = "init_treat_as_empty_struct_context", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void init_treat_as_empty_struct_context(TreatAsEmptyStruct** _out);
+
+        [DllImport(__DllName, EntryPoint = "free_treat_as_empty_struct_context", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void free_treat_as_empty_struct_context(TreatAsEmptyStruct* _src);
+
 
     }
 
@@ -258,6 +264,11 @@ namespace CsBindgen
     {
         public delegate* unmanaged[Cdecl]<void> foo;
         public delegate* unmanaged[Cdecl]<int, int> foobar;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe partial struct TreatAsEmptyStruct
+    {
     }
 
 


### PR DESCRIPTION
When we handle struct in FFI, we basically use `#[repr(C)]` .
Also, Rust often exposes Unit struct to hide the struct structure, and FFI uses a reference to that struct.
https://github.com/Cysharp/csbindgen?tab=readme-ov-file#struct

With the `Box<T>` support from v1.7.5 of csbindgen, we can now deal with structures with C and C# in the following ways.

```rust
// no repr(C)
pub struct MyContext {
    internal_field: HashSet<i32>,
}

pub unsafe extern "C" fn init_context(
    out_context: NonNull<Box<MyContext>>,
) {
    let c = MyContext {
        internal_field: HashSet::new()
    };

    out_context.as_ptr().write_unaligned(Box::from(c));
}

pub extern "C" fn context_delete(context: Box<MyContext>) {
    drop(context);
}
```

By wrapping in a Box like this, we do not have to care about the size of the struct on the C# side.

I thought it would be useful to be able to use Rust's internal types without considering `#[repr(C)]`, as in the sample above, so I made a change to treat structures without repc(C) as if they were Unit struct.


