### PR TITLE
Support reference type ( & )

### DIFF
--- a/csbindgen-tests/src/lib.rs
+++ b/csbindgen-tests/src/lib.rs
@@ -606,6 +606,8 @@ pub struct CallbackTable {
     pub foobar: extern "C" fn(i: i32) -> i32,
 }
 
+pub extern "C" fn reference_type(_a: &i32, _b: &*mut i32, _c: &[u8; 16], _d: &Context) {}
+
 // fn run_physix(){
 //     unsafe {
 //         let foundation = physx_create_foundation();

--- a/dotnet-sandbox/NativeMethods.cs
+++ b/dotnet-sandbox/NativeMethods.cs
@@ -176,6 +176,9 @@ namespace CsBindgen
         [DllImport(__DllName, EntryPoint = "call_bindgen_lz4", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void call_bindgen_lz4();
 
+        [DllImport(__DllName, EntryPoint = "reference_type", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void reference_type(int* _a, int** _b, void/* byte[] */* _c, Context* _d);
+
 
     }
 


### PR DESCRIPTION
`&` means for lifetime or borrow in the Rust context, but when expressed as a C ABI, these seem no different for pointers.
Therefore, I implemented a parser that basically works the same as Pointer.