### PR TITLE
Change the csharp_generate_const to csharp_generate_const_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ csbindgen::Builder::default()
     .csharp_use_function_pointer(true)      // optional, default: true
     .csharp_disable_emit_dll_name(false)    // optional, default: false
     .csharp_imported_namespaces("MyLib")    // optional, default: empty
-    .csharp_generate_const (false)          // optional, default: false
+    .csharp_generate_const_fliter (|_|false) // optional, default: `|_|false`
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
     .generate_csharp_file("../dotnet-sandbox/NativeMethods.cs")     // required
     .unwrap();
@@ -196,7 +196,7 @@ namespace {csharp_namespace}
 #endif
     }
 
-    {csharp_generate_const}
+    {csharp_generate_const_fliter}
 
     [DllImport(__DllName, EntryPoint = "{csharp_entry_point_prefix}LZ4_versionNumber", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern int {csharp_method_prefix}LZ4_versionNumber();
@@ -207,7 +207,7 @@ namespace {csharp_namespace}
 
 `csharp_disable_emit_dll_name` is optional, if set to true then don't emit `const string __DllName`. It is useful for generate same class-name from different builder.
 
-`csharp_generate_const` is optional, if set to true then generate C# `const` field from Rust `const`.
+`csharp_generate_const_fliter` is optional, if set a fliter fun, then generate fliter C# `const` field from Rust `const`.
 
 `input_extern_file` and `input_bindgen_file` allow mulitple call, if you need to add dependent struct, use this.
 
@@ -272,7 +272,7 @@ csbindgen::Builder::default()
     .csharp_method_prefix("")                     // optional, default: ""
     .csharp_use_function_pointer(true)            // optional, default: true
     .csharp_imported_namespaces("MyLib")          // optional, default: empty
-    .csharp_generate_const (false)                // optional, default: false
+    .csharp_generate_const_filter(|_|false)       // optional, default:|_|false
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
     .generate_to_file("src/lz4_ffi.rs", "../dotnet-sandbox/lz4_bindgen.cs") // required
     .unwrap();

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ csbindgen::Builder::default()
     .csharp_use_function_pointer(true)      // optional, default: true
     .csharp_disable_emit_dll_name(false)    // optional, default: false
     .csharp_imported_namespaces("MyLib")    // optional, default: empty
-    .csharp_generate_const_fliter (|_|false) // optional, default: `|_|false`
+    .csharp_generate_const_filter (|_|false) // optional, default: `|_|false`
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
     .generate_csharp_file("../dotnet-sandbox/NativeMethods.cs")     // required
     .unwrap();
@@ -196,7 +196,7 @@ namespace {csharp_namespace}
 #endif
     }
 
-    {csharp_generate_const_fliter}
+    {csharp_generate_const_filter}
 
     [DllImport(__DllName, EntryPoint = "{csharp_entry_point_prefix}LZ4_versionNumber", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern int {csharp_method_prefix}LZ4_versionNumber();
@@ -207,7 +207,7 @@ namespace {csharp_namespace}
 
 `csharp_disable_emit_dll_name` is optional, if set to true then don't emit `const string __DllName`. It is useful for generate same class-name from different builder.
 
-`csharp_generate_const_fliter` is optional, if set a fliter fun, then generate fliter C# `const` field from Rust `const`.
+`csharp_generate_const_filter` is optional, if set a fliter fun, then generate filter C# `const` field from Rust `const`.
 
 `input_extern_file` and `input_bindgen_file` allow mulitple call, if you need to add dependent struct, use this.
 

--- a/csbindgen-tests/build.rs
+++ b/csbindgen-tests/build.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         //.csharp_c_long_convert("int")
         //.csharp_c_ulong_convert("uint")
         // .csharp_use_function_pointer(true)
-        .csharp_generate_const(true)
+        .csharp_generate_const_filter(|_|true)
         .generate_to_file("src/lz4_ffi.rs", "../dotnet-sandbox/lz4_bindgen.cs")
         .unwrap();
 
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .csharp_dll_name("csbindgen_tests")
         .csharp_use_function_pointer(true)
         //.csharp_use_function_pointer(false)
-        .csharp_generate_const(true)
+        .csharp_generate_const_filter(|_|true)
         .generate_csharp_file("../dotnet-sandbox/NativeMethods.cs")
         .unwrap();
 
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .rust_file_header("use super::bullet3::*;")
         .csharp_class_name("LibBullet3")
         .csharp_dll_name("libbullet3")
-        .csharp_generate_const(true)
+        .csharp_generate_const_filter(|_|true)
         .generate_to_file("src/bullet3_ffi.rs", "../dotnet-sandbox/bullet3_bindgen.cs")?;
 
     csbindgen::Builder::new()

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -30,7 +30,7 @@ pub struct BindgenOptions {
     pub csharp_if_dll_name: String,
     pub csharp_use_function_pointer: bool,
     pub csharp_imported_namespaces: Vec<String>,
-    pub csharp_generate_const: bool,
+    pub csharp_generate_const_filter: fn(const_name: &str) -> bool,
 }
 
 impl Default for Builder {
@@ -54,7 +54,7 @@ impl Default for Builder {
                 csharp_if_dll_name: "".to_string(),
                 csharp_use_function_pointer: true,
                 csharp_imported_namespaces: vec![],
-                csharp_generate_const: false,
+                csharp_generate_const_filter: |_| false,
             },
         }
     }
@@ -84,6 +84,8 @@ impl Builder {
         self.options.method_filter = method_filter;
         self
     }
+
+    
 
     /// add original extern call type prefix to rust wrapper,
     /// `return {rust_method_type_path}::foo()`
@@ -177,15 +179,15 @@ impl Builder {
         self
     }
 
-    /// conifure C# generate function pointer as delegate* or Func/Action, default is true(generate delegate*)
+    /// configure C# generate function pointer as delegate* or Func/Action, default is true(generate delegate*)
     pub fn csharp_use_function_pointer(mut self, csharp_use_function_pointer: bool) -> Builder {
         self.options.csharp_use_function_pointer = csharp_use_function_pointer;
         self
     }
 
-    /// conifure C# generate const, default is false
-    pub fn csharp_generate_const(mut self, csharp_generate_const: bool) -> Builder {
-        self.options.csharp_generate_const = csharp_generate_const;
+    /// configure C# generate const filter, default `|_| false`
+    pub fn csharp_generate_const_filter(mut self, csharp_generate_const_filter: fn(const_name: &str) -> bool) -> Builder {
+        self.options.csharp_generate_const_filter = csharp_generate_const_filter;
         self
     }
 

--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -291,7 +291,7 @@ pub fn emit_csharp(
         enum_string.push('\n');
     }
 
-    let mut const_string = String::new();
+    let mut const_string: String = String::new();
     for item in consts {
         let mut type_name = item.rust_type.to_csharp_string(
             options,

--- a/csbindgen/src/lib.rs
+++ b/csbindgen/src/lib.rs
@@ -49,9 +49,8 @@ pub(crate) fn generate(
         collect_struct(&file_ast, &mut structs);
         collect_enum(&file_ast, &mut enums);
 
-        if options.csharp_generate_const {
-            collect_const(&file_ast, &mut consts);
-        }
+        collect_const(&file_ast, &mut consts,options.csharp_generate_const_filter);
+       
     }
 
     // collect using_types

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -251,12 +251,12 @@ fn collect_fields_unnamed(fields: &syn::FieldsUnnamed) -> Vec<FieldMember> {
     result
 }
 
-pub fn collect_const(ast: &syn::File, result: &mut Vec<RustConst>,fliter:fn(const_name: &str) -> bool) {
+pub fn collect_const(ast: &syn::File, result: &mut Vec<RustConst>,filter:fn(const_name: &str) -> bool) {
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Const(ct) = item {
             // pub const Ident: ty = expr
             let const_name = ct.ident.to_string();
-            if fliter(const_name.as_str()) {
+            if filter(const_name.as_str()) {
                 
             let t = parse_type(&ct.ty);
 

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -251,11 +251,13 @@ fn collect_fields_unnamed(fields: &syn::FieldsUnnamed) -> Vec<FieldMember> {
     result
 }
 
-pub fn collect_const(ast: &syn::File, result: &mut Vec<RustConst>) {
+pub fn collect_const(ast: &syn::File, result: &mut Vec<RustConst>,fliter:fn(const_name: &str) -> bool) {
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Const(ct) = item {
             // pub const Ident: ty = expr
             let const_name = ct.ident.to_string();
+            if fliter(const_name.as_str()) {
+                
             let t = parse_type(&ct.ty);
 
             if let syn::Expr::Lit(lit_expr) = &*ct.expr {
@@ -290,6 +292,7 @@ pub fn collect_const(ast: &syn::File, result: &mut Vec<RustConst>) {
                     value: value,
                 });
             }
+        }
         }
     }
 }


### PR DESCRIPTION
the csharp_generate_const_filter can replace the csharp_generate_const 's function.also supply the filter the const name.
when i used the csharp_generate_const ,it include a lot of system's const vale that i do not needed.
by add the filter fn,we can just import our clib const