### PR TITLE
Added compatibility with repr(C) enum types, defaulting to uint type

### DIFF
--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -376,6 +376,7 @@ namespace {namespace}
 
 fn convert_token_enum_repr(repr: &str) -> &str {
     match repr {
+        "(C)" => "uint",
         "(u8)" => "byte",
         "(u16)" => "ushort",
         "(u32)" => "uint",


### PR DESCRIPTION
Having a `repr(C)` enum is syntactically perfectly legal and used, even though the specs are not clear on what underlying type is used for such an enum. Checking both documentation online and testing with several OS (macOS, Windows, Linux) and architectures (x86, x86-64 and aarch64) `u32` (i.e. `uint`) seems to be the correct choice on all platforms where C# interop is reasonable to happen.

Still, without this a `repr(C)` enum would produce code that wouldn't compile at all.