### PR TITLE
Adds a setting to force some types to always be included in the emitted types

### DIFF
--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -32,6 +32,7 @@ pub struct BindgenOptions {
     pub csharp_use_nint_types: bool,
     pub csharp_imported_namespaces: Vec<String>,
     pub csharp_generate_const_filter: fn(const_name: &str) -> bool,
+    pub always_included_types: Vec<String>,
 }
 
 impl Default for Builder {
@@ -57,6 +58,7 @@ impl Default for Builder {
                 csharp_use_nint_types: true,
                 csharp_imported_namespaces: vec![],
                 csharp_generate_const_filter: |_| false,
+                always_included_types: vec![],
             },
         }
     }
@@ -87,7 +89,14 @@ impl Builder {
         self
     }
 
-
+    /// Adds a list of types that will always be considered to be included in the
+    /// generated bindings, even if not part of any function signature
+    pub fn always_included_types<I, S>(mut self, always_included_types: I) -> Builder
+    where I: IntoIterator<Item = S>, S: ToString
+    {
+        self.options.always_included_types.extend(always_included_types.into_iter().map(|v| v.to_string()));
+        self
+    }
 
     /// add original extern call type prefix to rust wrapper,
     /// `return {rust_method_type_path}::foo()`

--- a/csbindgen/src/lib.rs
+++ b/csbindgen/src/lib.rs
@@ -78,6 +78,8 @@ pub(crate) fn generate(
         }
     }
 
+    using_types.extend(options.always_included_types.iter().cloned());
+
     let structs = reduce_struct(&structs, &field_map, &using_types);
     let enums = reduce_enum(&enums, &field_map, &using_types);
 


### PR DESCRIPTION
This is useful to support, for example, enum types whose values are significant but whose type is not explicitly used in the functions prototypes.

For example in this code:

```rust
/// Returns the id of an opened object, or - if negative - an error code
#[no_mangle]
pub extern "C" fn open_object() -> i64 {
...
}

#[repr(i64)]
pub enum ErrorCode {
     InvalidState = -1,
     BadMood = -2,
     NotAGoodDay = -3,
}
```

`ErrorCode`  would not be emitted in the generated bindings because it doesn't appear in `open_object` prototype even if it is a potential return type.