### PR TITLE
Add checks on no_mangle & test attributes, on pub visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ csbindgen::Builder::default()
     .rust_method_prefix("csbindgen_")             // optional, default: "csbindgen_"
     .rust_file_header("use super::lz4::*;")       // optional, default: ""
     .rust_method_type_path("lz4")                 // optional, default: ""
+    .rust_disable_mangle(true)                    // optional, default: true
     .csharp_dll_name("lz4")                       // required
     .csharp_class_name("NativeMethods")           // optional, default: NativeMethods
     .csharp_namespace("CsBindgen")                // optional, default: CsBindgen

--- a/csbindgen-tests/build.rs
+++ b/csbindgen-tests/build.rs
@@ -51,6 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .rust_method_prefix("csbindgen_")
         .rust_file_header("use super::lz4;")
         .rust_method_type_path("lz4")
+        .rust_disable_mangle(true)
         .csharp_class_name("LibLz4")
         .csharp_namespace("CsBindgen")
         .csharp_dll_name("csbindgen_tests")

--- a/csbindgen-tests/src/lib.rs
+++ b/csbindgen-tests/src/lib.rs
@@ -683,7 +683,7 @@ pub unsafe extern "C" fn free_treat_as_empty_struct_context(_src: *mut TreatAsEm
 //     }
 // }
 
-#[export_name = custom_name]
+#[export_name = "custom_name"]
 pub fn does_this_export() {
     //pass
 }

--- a/csbindgen-tests/src/lib.rs
+++ b/csbindgen-tests/src/lib.rs
@@ -682,3 +682,8 @@ pub unsafe extern "C" fn free_treat_as_empty_struct_context(_src: *mut TreatAsEm
 //         // Your physics simulation goes here
 //     }
 // }
+
+#[export_name = custom_name]
+pub fn does_this_export() {
+    //pass
+}

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -112,7 +112,8 @@ impl Builder {
         self
     }
 
-    /// disable generating of bindings for functions without `#[no_mangle]` attribute
+    /// disable generating of bindings for functions without `#[no_mangle]` or
+    /// `#[export_name = name]` attribute
     pub fn rust_disable_mangle(mut self, rust_disable_mangle: bool) -> Builder {
         self.options.rust_disable_mangle = rust_disable_mangle;
         self

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -19,6 +19,7 @@ pub struct BindgenOptions {
     pub rust_method_type_path: String,
     pub rust_method_prefix: String,
     pub rust_file_header: String,
+    pub rust_disable_mangle: bool,
     pub csharp_namespace: String,
     pub csharp_class_name: String,
     pub csharp_dll_name: String,
@@ -44,6 +45,7 @@ impl Default for Builder {
                 rust_method_type_path: "".to_string(),
                 rust_method_prefix: "csbindgen_".to_string(),
                 rust_file_header: "".to_string(),
+                rust_disable_mangle: true,
                 csharp_namespace: "CsBindgen".to_string(),
                 csharp_class_name: "NativeMethods".to_string(),
                 csharp_dll_name: "".to_string(),
@@ -107,6 +109,12 @@ impl Builder {
     /// `mod lz4;`, `use super::lz4;`
     pub fn rust_file_header<T: Into<String>>(mut self, rust_file_header: T) -> Builder {
         self.options.rust_file_header = rust_file_header.into();
+        self
+    }
+
+    /// disable generating of bindings for functions without `#[no_mangle]` attribute
+    pub fn rust_disable_mangle(mut self, rust_disable_mangle: bool) -> Builder {
+        self.options.rust_disable_mangle = rust_disable_mangle;
         self
     }
 

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -40,12 +40,9 @@ pub fn collect_foreign_method(
         if let Item::ForeignMod(m) = item {
             for item in m.items.iter() {
                 if let ForeignItem::Fn(m) = item {
-                    // has pub and so it exports in Rust
-                    if let Visibility::Public(_) = m.vis {
-                        let method = parse_method(FnItem::ForeignItem(m.clone()), options);
-                        if let Some(x) = method {
-                            list.push(x);
-                        }
+                    let method = parse_method(FnItem::ForeignItem(m.clone()), options);
+                    if let Some(x) = method {
+                        list.push(x);
                     }
                 }
             }
@@ -61,13 +58,10 @@ pub fn collect_extern_method(
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Fn(m) = item {
             if m.sig.abi.is_some() {
-                // has pub and so it exports in Rust
-                if let Visibility::Public(_) = m.vis {
-                    // has extern
-                    let method = parse_method(FnItem::Item(m.clone()), options);
-                    if let Some(x) = method {
-                        list.push(x);
-                    }
+                // has extern
+                let method = parse_method(FnItem::Item(m.clone()), options);
+                if let Some(x) = method {
+                    list.push(x);
                 }
             }
         }
@@ -83,7 +77,7 @@ fn parse_method(item: FnItem, options: &BindgenOptions) -> Option<ExternMethod> 
     let mut has_no_mangle = false;
     for attr in &attrs {
         let attr_name = attr.path.to_token_stream().to_string();
-        if attr_name == "no_mangle" {
+        if attr_name == "no_mangle" || attr_name == "export_name" {
             has_no_mangle = true;
         }
         else if attr_name == "test" {


### PR DESCRIPTION
Applies as implementation for #58.
Now `csbindgen::Builder` has an option `rust_disable_mangle` that by default equals `true`. It means that bindings for functions without attribute `#[no_mangle]` will not be generated. Also I add check on attribute `#[test]` (function will not be passed if it has this attribute)  and on `pub` visibility (function will not be passed if it has other visibility).