### PR TITLE
Fix condition of the function to be targeted.

### DIFF
--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -1,6 +1,7 @@
 use crate::alias_map::AliasMap;
 use crate::builder::BindgenOptions;
 use crate::type_meta::*;
+use crate::type_meta::ExportSymbolNaming::{ExportName, NoMangle};
 use crate::util::*;
 
 pub fn emit_rust_method(list: &Vec<ExternMethod>, options: &BindgenOptions) -> String {
@@ -152,9 +153,14 @@ pub fn emit_csharp(
             }
         }
 
+        let entry_point = match &item.export_naming  {
+            NoMangle => &item.method_name,
+            ExportName(export_name) => export_name
+        };
+
         let entry_point = match options.csharp_entry_point_prefix.as_str() {
-            "" => format!("{method_prefix}{method_name}"),
-            x => format!("{x}{method_name}"),
+            "" => format!("{method_prefix}{entry_point}"),
+            x => format!("{x}{entry_point}"),
         };
         let return_type = match &item.return_type {
             Some(x) => {

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -57,13 +57,11 @@ pub fn collect_extern_method(
 ) {
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Fn(m) = item {
-            // has extern "C"
-            if let Some(abi_name) =  m.sig.abi.as_ref().and_then(|x| x.name.as_ref()) {
-                if abi_name.value() == "C" {
-                    let method = parse_method(FnItem::Item(m.clone()), options);
-                    if let Some(x) = method {
-                        list.push(x);
-                    }
+            // has extern
+            if m.sig.abi.is_some() {
+                let method = parse_method(FnItem::Item(m.clone()), options);
+                if let Some(x) = method {
+                    list.push(x);
                 }
             }
         }

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -1,7 +1,8 @@
 use crate::{alias_map::AliasMap, builder::BindgenOptions, field_map::FieldMap, type_meta::*};
 use regex::Regex;
 use std::collections::HashSet;
-use syn::{ForeignItem, Item, Pat, ReturnType};
+use syn::{ForeignItem, Ident, Item, Meta, MetaNameValue, Pat, ReturnType};
+use crate::type_meta::ExportSymbolNaming::{ExportName, NoMangle};
 
 enum FnItem {
     ForeignItem(syn::ForeignItemFn),
@@ -56,8 +57,8 @@ pub fn collect_extern_method(
 ) {
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Fn(m) = item {
-            if m.sig.abi.is_some() {
-                // has extern
+            // has extern "C"
+            if m.sig.abi.as_ref().and_then(|x| x.name.as_ref()).filter(|x| x.value() == "C").is_some() {
                 let method = parse_method(FnItem::Item(m.clone()), options);
                 if let Some(x) = method {
                     list.push(x);
@@ -68,9 +69,9 @@ pub fn collect_extern_method(
 }
 
 fn parse_method(item: FnItem, options: &BindgenOptions) -> Option<ExternMethod> {
-    let (sig, attrs) = match item {
-        FnItem::ForeignItem(x) => (x.sig, x.attrs),
-        FnItem::Item(x) => (x.sig, x.attrs),
+    let (sig, attrs, is_foreign_item) = match item {
+        FnItem::ForeignItem(x) => (x.sig, x.attrs, true),
+        FnItem::Item(x) => (x.sig, x.attrs, false),
     };
 
     let method_name = sig.ident.to_string();
@@ -114,6 +115,35 @@ fn parse_method(item: FnItem, options: &BindgenOptions) -> Option<ExternMethod> 
         return_type = Some(rust_type);
     }
 
+    // check attrs
+    let mut export_naming = NoMangle;
+    if (!is_foreign_item) {
+        let found = attrs.iter()
+            .map(|attr| {
+                let name = &attr.path.segments.last().unwrap().ident;
+                if (name == "no_mangle") {
+                    return Some(NoMangle)
+                } else if (name == "export_name") {
+                    if let Ok(Meta::NameValue(MetaNameValue { lit: syn::Lit::Str(x), .. })) = attr.parse_meta() {
+                        return Some(ExportName(x.value()));
+                    }
+                }
+                None
+            })
+            .flatten()
+            .next();
+
+        if let Some(x) = found {
+            export_naming = x;
+        } else {
+            println!(
+                "csbindgen can't handle this function because there is neither #[no_mangle] nor #[export_name] so ignore generate, method_name: {}",
+                method_name
+            );
+            return None;
+        }
+    }
+
     // doc
     let doc_comment = attrs
         .iter()
@@ -124,6 +154,7 @@ fn parse_method(item: FnItem, options: &BindgenOptions) -> Option<ExternMethod> 
     if !method_name.is_empty() && (options.method_filter)(method_name.clone()) {
         return Some(ExternMethod {
             method_name,
+            export_naming,
             parameters,
             return_type,
             doc_comment,

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{alias_map::AliasMap, builder::BindgenOptions, field_map::FieldMap, type_meta::*};
 use regex::Regex;
 use std::collections::HashSet;
-use syn::{ForeignItem, Ident, Item, Meta, MetaNameValue, Pat, ReturnType};
+use syn::{Abi, ForeignItem, Ident, Item, Meta, MetaNameValue, Pat, ReturnType};
 use crate::type_meta::ExportSymbolNaming::{ExportName, NoMangle};
 
 enum FnItem {
@@ -58,10 +58,12 @@ pub fn collect_extern_method(
     for item in depth_first_module_walk(&ast.items) {
         if let Item::Fn(m) = item {
             // has extern "C"
-            if m.sig.abi.as_ref().and_then(|x| x.name.as_ref()).filter(|x| x.value() == "C").is_some() {
-                let method = parse_method(FnItem::Item(m.clone()), options);
-                if let Some(x) = method {
-                    list.push(x);
+            if let Some(abi_name) =  m.sig.abi.as_ref().and_then(|x| x.name.as_ref()) {
+                if abi_name.value() == "C" {
+                    let method = parse_method(FnItem::Item(m.clone()), options);
+                    if let Some(x) = method {
+                        list.push(x);
+                    }
                 }
             }
         }

--- a/csbindgen/src/type_meta.rs
+++ b/csbindgen/src/type_meta.rs
@@ -30,11 +30,18 @@ pub struct FieldMember {
 }
 
 #[derive(Clone, Debug)]
+pub enum ExportSymbolNaming {
+    NoMangle,
+    ExportName(String),
+}
+
+#[derive(Clone, Debug)]
 pub struct ExternMethod {
     pub method_name: String,
     pub doc_comment: Vec<String>,
     pub parameters: Vec<Parameter>,
     pub return_type: Option<RustType>,
+    pub export_naming: ExportSymbolNaming,
 }
 
 impl ExternMethod {


### PR DESCRIPTION
refs: #58, https://github.com/Cysharp/csbindgen/pull/60#issuecomment-1785209608

Besides using no_mangle, it seems that the `#[export_name]` attribute can emit symbol names without mangling.
Therefore, we would like to support this method of specification.
And only with `#[no_mangle]` or `#[export_name = ...]` are included. Otherwise, it print a message. 


e.g)

```rust
#[export_name = "foo_bar"]
pub extern "C" fn foo()  {
    // ...
}
```

```csharp
[DllImport(__DllName, EntryPoint = "foo_bar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
public static extern int foo();
```