### PR TITLE
Add option to change the type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ csbindgen::Builder::default()
     .csharp_imported_namespaces("MyLib")    // optional, default: empty
     .csharp_generate_const_filter (|_|false) // optional, default: `|_|false`
     .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
+    .csharp_type_rename(|rust_type_name| match rust_type_name {     // optional, default: `|x| x`
+        "FfiConfiguration" => "Configuration".into(),
+        _ => x,
+    })
     .generate_csharp_file("../dotnet-sandbox/NativeMethods.cs")     // required
     .unwrap();
 ```
@@ -290,7 +294,11 @@ csbindgen::Builder::default()
     .csharp_use_function_pointer(true)            // optional, default: true
     .csharp_imported_namespaces("MyLib")          // optional, default: empty
     .csharp_generate_const_filter(|_|false)       // optional, default:|_|false
-    .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal") // optional, default: ""
+    .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal")         // optional, default: ""
+    .csharp_type_rename(|rust_type_name| match rust_type_name.as_str() {    // optional, default: `|x| x`
+        "FfiConfiguration" => "Configuration".into(),
+        _ => x,
+    })
     .generate_to_file("src/lz4_ffi.rs", "../dotnet-sandbox/lz4_bindgen.cs") // required
     .unwrap();
 ```

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -219,7 +219,7 @@ impl Builder {
         self
     }
 
-    /// configure the mappings that C# type name from rust original type name, default `|x| x.to_string()`
+    /// configure the mappings that C# type name from rust original type name, default `|x| x`
     pub fn csharp_type_rename(mut self, csharp_type_rename: fn(rust_type_name: String) -> String) -> Builder {
         self.options.csharp_type_rename = csharp_type_rename;
         self

--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -5,6 +5,7 @@ use std::{
     io::{self, Write},
     path::Path,
 };
+use std::convert::identity;
 
 use crate::{generate, GenerateKind};
 
@@ -32,6 +33,7 @@ pub struct BindgenOptions {
     pub csharp_use_nint_types: bool,
     pub csharp_imported_namespaces: Vec<String>,
     pub csharp_generate_const_filter: fn(const_name: &str) -> bool,
+    pub csharp_type_rename: fn(type_name: String) -> String,
     pub always_included_types: Vec<String>,
 }
 
@@ -58,6 +60,7 @@ impl Default for Builder {
                 csharp_use_nint_types: true,
                 csharp_imported_namespaces: vec![],
                 csharp_generate_const_filter: |_| false,
+                csharp_type_rename: identity,
                 always_included_types: vec![],
             },
         }
@@ -92,7 +95,7 @@ impl Builder {
     /// Adds a list of types that will always be considered to be included in the
     /// generated bindings, even if not part of any function signature
     pub fn always_included_types<I, S>(mut self, always_included_types: I) -> Builder
-    where I: IntoIterator<Item = S>, S: ToString
+        where I: IntoIterator<Item = S>, S: ToString
     {
         self.options.always_included_types.extend(always_included_types.into_iter().map(|v| v.to_string()));
         self
@@ -213,6 +216,12 @@ impl Builder {
     /// configure C# generate const filter, default `|_| false`
     pub fn csharp_generate_const_filter(mut self, csharp_generate_const_filter: fn(const_name: &str) -> bool) -> Builder {
         self.options.csharp_generate_const_filter = csharp_generate_const_filter;
+        self
+    }
+
+    /// configure the mappings that C# type name from rust original type name, default `|x| x.to_string()`
+    pub fn csharp_type_rename(mut self, csharp_type_rename: fn(rust_type_name: String) -> String) -> Builder {
+        self.options.csharp_type_rename = csharp_type_rename;
         self
     }
 

--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -204,7 +204,7 @@ pub fn emit_csharp(
 
     let mut structs_string = String::new();
     for item in structs {
-        let name = escape_csharp_name(&item.struct_name);
+        let name = (options.csharp_type_rename)(escape_csharp_name(&item.struct_name));
         let layout_kind = if item.is_union {
             "Explicit"
         } else {

--- a/csbindgen/src/type_meta.rs
+++ b/csbindgen/src/type_meta.rs
@@ -279,7 +279,7 @@ impl RustType {
                 "NonZeroUsize" if use_nint_types => "nuint",
                 "NonZeroUsize" => "System.UIntPtr",
                 _ => {
-                    temp_string = escape_csharp_name(type_name);
+                    temp_string = (options.csharp_type_rename)(escape_csharp_name(type_name));
                     temp_string.as_str()
                 }
             };


### PR DESCRIPTION
refs: #56 

I've added the  following option .

```rust
    .csharp_type_rename(|rust_type_name| match rust_type_name {     // optional, default: `|x| x`
        "FfiConfiguration" => "Configuration".into(),
        _ => x,
    })
```

