### PR TITLE
Readme: Use Process, not OS Architecture to Decide which Library to Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,15 +366,15 @@ internal static unsafe partial class NativeMethods
                 extension = ".so";
             }
 
-            if (RuntimeInformation.OSArchitecture == Architecture.X86)
+            if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
             {
                 path += "x86";
             }
-            else if (RuntimeInformation.OSArchitecture == Architecture.X64)
+            else if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
             {
                 path += "x64";
             }
-            else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+            else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
                 path += "arm64";
             }


### PR DESCRIPTION
The previous example is prone to failure in situations where you are running a 32-bit application on a 64-bit OS, for example running an x86 process on an x86_64 OS. 

The revised example uses the `Process`, not the `OS` architecture; which should hopefully alleviate this problem.

(Misc Note: Big fan of your work! Save the frames!)