### PR TITLE
Added "delayed" generation of delegate signatures.

### DIFF
--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::alias_map::AliasMap;
 use crate::builder::BindgenOptions;
 use crate::type_meta::*;
@@ -88,6 +90,7 @@ pub fn emit_csharp(
     let class_name = &options.csharp_class_name;
     let method_prefix = &options.csharp_method_prefix;
     let accessibility = &options.csharp_class_accessibility;
+    let mut forward_decls: HashSet<String> = HashSet::new();
 
     let mut dll_name = match options.csharp_if_symbol.as_str() {
         "" => format!(
@@ -126,6 +129,7 @@ pub fn emit_csharp(
                 aliases,
                 method_name,
                 &"return".to_string(),
+                &mut forward_decls,
             ) {
                 method_list_string.push_str(
                     format!("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n")
@@ -143,6 +147,7 @@ pub fn emit_csharp(
                 aliases,
                 method_name,
                 &p.name,
+                &mut forward_decls,
             ) {
                 method_list_string.push_str(
                     format!("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n")
@@ -164,7 +169,7 @@ pub fn emit_csharp(
         };
         let return_type = match &item.return_type {
             Some(x) => {
-                x.to_csharp_string(options, aliases, false, method_name, &"return".to_string())
+                x.to_csharp_string(options, aliases, false, method_name, &"return".to_string(), &mut forward_decls)
             }
             None => "void".to_string(),
         };
@@ -175,7 +180,7 @@ pub fn emit_csharp(
             .map(|p| {
                 let mut type_name =
                     p.rust_type
-                        .to_csharp_string(options, aliases, false, method_name, &p.name);
+                        .to_csharp_string(options, aliases, false, method_name, &p.name, &mut forward_decls);
                 if type_name == "bool" {
                     type_name = "[MarshalAs(UnmanagedType.U1)] bool".to_string();
                 }
@@ -227,6 +232,7 @@ pub fn emit_csharp(
                 true,
                 &"".to_string(),
                 &"".to_string(),
+                &mut forward_decls,
             );
             let attr = if type_name == "bool" {
                 "[MarshalAs(UnmanagedType.U1)] ".to_string()
@@ -305,6 +311,7 @@ pub fn emit_csharp(
             false,
             &"".to_string(),
             &"".to_string(),
+            &mut forward_decls,
         );
 
         // special case for string, char, ByteStr
@@ -361,6 +368,8 @@ pub fn emit_csharp(
         imported_namespaces.push_str_ln(format!("using {name};").as_str());
     }
 
+    let forward_decls_string = forward_decls.drain().collect::<Vec<_>>().join("\n");
+
     let result = format!(
 "{file_header}
 using System;
@@ -376,6 +385,7 @@ namespace {namespace}
 {const_string}
 
 {method_list_string}
+{forward_decls_string}
     }}
 
 {structs_string}

--- a/csbindgen/src/type_meta.rs
+++ b/csbindgen/src/type_meta.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::{alias_map::AliasMap, builder::BindgenOptions};
 
 pub fn escape_csharp_name(str: &str) -> String {
@@ -220,6 +222,7 @@ impl RustType {
         emit_from_struct: bool,
         method_name: &String,
         parameter_name: &String,
+        forward_decls: &mut HashSet<String>,
     ) -> String {
         fn convert_type_name(type_name: &str, options: &BindgenOptions) -> String {
             let temp_string: String;
@@ -300,6 +303,7 @@ impl RustType {
                 emit_from_struct,
                 method_name,
                 parameter_name,
+                forward_decls,
             )
         } else {
             convert_type_name(use_type.type_name.as_str(), options).to_string()
@@ -339,6 +343,7 @@ impl RustType {
                             emit_from_struct,
                             method_name,
                             parameter_name,
+                            forward_decls,
                         ));
                         sb.push_str(", ");
                     }
@@ -350,6 +355,7 @@ impl RustType {
                                 emit_from_struct,
                                 method_name,
                                 parameter_name,
+                                forward_decls,
                             ));
                         }
                         None => {
@@ -358,7 +364,15 @@ impl RustType {
                     };
                     sb.push('>');
                 } else {
-                    sb.push_str(build_method_delegate_name(method_name, parameter_name).as_str());
+                    let delegate_name = build_method_delegate_name(method_name, parameter_name);
+
+                    sb.push_str(&delegate_name);
+
+                    let decl = build_method_delegate_if_required(self, options, alias_map, method_name, parameter_name, forward_decls);
+
+                    if let Some(decl) = decl {
+                        forward_decls.insert(format!("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n        public {decl};"));
+                    }
                 }
             }
             TypeKind::Option(inner) => {
@@ -371,6 +385,7 @@ impl RustType {
                             emit_from_struct,
                             method_name,
                             parameter_name,
+                            forward_decls,
                         )
                         .as_str(),
                 );
@@ -385,6 +400,7 @@ impl RustType {
                     method_name: &String,
                     parameter_name: &String,
                     emit_inner: bool,
+                    forward_decls: &mut HashSet<String>,
                 ) -> bool {
                     use PointerType::*;
                     if let TypeKind::Pointer(p, inner) = &rust_type.type_kind {
@@ -397,6 +413,7 @@ impl RustType {
                                         emit_from_struct,
                                         method_name,
                                         parameter_name,
+                                        forward_decls,
                                     )
                                     .as_str(),
                             );
@@ -428,6 +445,7 @@ impl RustType {
                         method_name,
                         parameter_name,
                         emit_inner,
+                        forward_decls,
                     ) {
                         sb.push_str(type_csharp_string.as_str());
                     }
@@ -444,6 +462,7 @@ impl RustType {
                     method_name,
                     parameter_name,
                     emit_inner,
+                    forward_decls,
                 ) {
                     if emit_inner {
                         sb.push_str(type_csharp_string.as_str());
@@ -462,6 +481,7 @@ pub fn build_method_delegate_if_required(
     alias_map: &AliasMap,
     method_name: &String,
     parameter_name: &String,
+    forward_decls: &mut HashSet<String>,
 ) -> Option<String> {
     let emit_from_struct = false;
 
@@ -479,6 +499,7 @@ pub fn build_method_delegate_if_required(
                         emit_from_struct,
                         method_name,
                         parameter_name,
+                        forward_decls,
                     ),
                     None => "void".to_string(),
                 };
@@ -493,6 +514,7 @@ pub fn build_method_delegate_if_required(
                             emit_from_struct,
                             method_name,
                             parameter_name,
+                            forward_decls,
                         );
                         let parameter_name = if p.name == "" {
                             format!("arg{}", index + 1)
@@ -517,6 +539,7 @@ pub fn build_method_delegate_if_required(
             alias_map,
             method_name,
             parameter_name,
+            forward_decls,
         ),
         _ => None,
     }


### PR DESCRIPTION
This is a reopening of #53, rebased on top of the latest `main` branch.

I apologize for not replying to the request of an example, sorry.

I'll show an example in this PR; I'm not 100% sure this is the best way to fix the issue, but we can start from this for a discussion.

---

### Description

Just as before, with this patch if a delegate is found during the construction of a method, its declaration is still emitted, after all the other types have been.

This is implemented through an HashSet of forward declarations that is used as now for delegates, but can be expanded to include other item types in the future.

---

### Example

Take this example Rust source:

```rust
#[no_mangle]
pub extern "C" fn set_callback(alloc_callback: extern "C" fn(size: usize, data: *const u16) -> *mut u8) {
    println!("Your callback is {alloc_callback:p}");
}
```

This **CORRECTLY** generates the following C# code:

```csharp
namespace ExampleNamespace
{
    internal static unsafe partial class NativeMethods
    {
        const string __DllName = "example.dll";

        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
        public delegate byte* set_callback_alloc_callback_delegate(System.UIntPtr size, ushort* data);

        [DllImport(__DllName, EntryPoint = "set_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
        public static extern void set_callback(set_callback_alloc_callback_delegate alloc_callback);
    }
}
```

So far so good. Now, that Rust declaration is nasty and would probably get refactored as:

```rust
type MyCallback = extern "C" fn(size: usize, data: *const u16) -> *mut u8;

#[no_mangle]
pub extern "C" fn set_callback(alloc_callback: MyCallback) {
    println!("Your callback is {alloc_callback:p}");
}
```

which produces

```csharp
namespace ExampleNamespace
{
    internal static unsafe partial class NativeMethods
    {
        const string __DllName = "example.dll";

        [DllImport(__DllName, EntryPoint = "set_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
        public static extern void set_callback(set_callback_alloc_callback_delegate alloc_callback);
    }
}
```

which is obviously bad because `set_callback_alloc_callback_delegate`'s definition is nowhere to be found.

The proposed fix produces this version instead:

```csharp
namespace ExampleNamespace
{
    internal static unsafe partial class NativeMethods
    {
        const string __DllName = "example.dll";

        [DllImport(__DllName, EntryPoint = "set_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
        public static extern void set_callback(set_callback_alloc_callback_delegate alloc_callback);

        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
        public delegate byte* set_callback_alloc_callback_delegate(System.UIntPtr size, ushort* data);
    }
}
```

---

### Differences from the version in PR #53 

The code is verbatim the same with these small differences: 

- in #53 the delegate declaration was being generated at the namespace level (as it does for other types like structs and enums), now I moved it to be at the class level to follow what it would do for the first Rust code in the example above
- added `public` visibility modifier, given that the declaration is now inside the class and would default to `private` instead of `internal`
- added the `[UnmanagedFunctionPointer(CallingConvention.Cdecl)]` boilerplate

