### PR TITLE
chore: csharp methods have the same visibility as structures and the class

### DIFF
--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -132,7 +132,7 @@ pub fn emit_csharp(
                         .as_str(),
                 );
                 method_list_string
-                    .push_str(format!("        public {delegate_method};\n\n").as_str());
+                    .push_str(format!("        {accessibility} {delegate_method};\n\n").as_str());
             }
         }
 
@@ -149,7 +149,7 @@ pub fn emit_csharp(
                         .as_str(),
                 );
                 method_list_string
-                    .push_str(format!("        public {delegate_method};\n\n").as_str());
+                    .push_str(format!("        {accessibility} {delegate_method};\n\n").as_str());
             }
         }
 
@@ -197,7 +197,7 @@ pub fn emit_csharp(
             method_list_string.push_str_ln("        [return: MarshalAs(UnmanagedType.U1)]");
         }
         method_list_string.push_str_ln(
-            format!("        public static extern {return_type} {method_prefix}{method_name}({parameters});").as_str(),
+            format!("        {accessibility} static extern {return_type} {method_prefix}{method_name}({parameters});").as_str(),
         );
         method_list_string.push('\n');
     }


### PR DESCRIPTION
Since the functions always have visibility public, if the class and the structures have visibility internal/private, then the c# compiler will complain with `CS0051` -- In general, its good to be able to modify the accessibility of PInvoke methods as they should ideally not be directly accessed outside of the project.