### PR TITLE
fix handling of MaybeUninit

### DIFF
--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -650,6 +650,8 @@ fn parse_type_path(t: &syn::TypePath) -> RustType {
                     type_name: "Box".to_string(),
                     type_kind: TypeKind::Pointer(PointerType::Box, Box::new(rust_type)),
                 };
+            } else if last_segment.ident == "MaybeUninit" {
+                return rust_type;
             }
         }
     }


### PR DESCRIPTION
With current csbindgen, type `MaybeUninit<some_type>` will be converted to `MaybeUninit` on the binding code. This behaviour makes the output code unusable because the information about the internal type is missing.

I modified the parser code to just ignore MaybeUninit<> and just use the internal type.
I'm not expert of Rust but I think it is ok, as MaybeUninit is for indicating that the memory is not initialized, I guess it can be ignored on binding code.

For reference, here's one of the code which uses MaybeUninit<>.
https://github.com/eclipse-zenoh/zenoh-c/blob/1010f5b6544f476a34046420a7a561e754ce6cbd/src/session.rs#L82-L86
