### PR TITLE
feat: support multiple `csharp_dll_name_if()`

### DIFF
--- a/csbindgen/src/builder.rs
+++ b/csbindgen/src/builder.rs
@@ -27,8 +27,7 @@ pub struct BindgenOptions {
     pub csharp_class_accessibility: String,
     pub csharp_entry_point_prefix: String,
     pub csharp_method_prefix: String,
-    pub csharp_if_symbol: String,
-    pub csharp_if_dll_name: String,
+    pub csharp_if_dll_imports: Vec<(String, String)>,
     pub csharp_use_function_pointer: bool,
     pub csharp_use_nint_types: bool,
     pub csharp_imported_namespaces: Vec<String>,
@@ -56,8 +55,7 @@ impl Default for Builder {
                 csharp_entry_point_prefix: "".to_string(),
                 csharp_method_prefix: "".to_string(),
                 csharp_class_accessibility: "internal".to_string(),
-                csharp_if_symbol: "".to_string(),
-                csharp_if_dll_name: "".to_string(),
+                csharp_if_dll_imports: vec![],
                 csharp_use_function_pointer: true,
                 csharp_use_nint_types: true,
                 csharp_imported_namespaces: vec![],
@@ -192,8 +190,7 @@ impl Builder {
     /// configure add C# dll name if directive,
     /// #if {if_symbol} __DllName = {if_dll_name}
     pub fn csharp_dll_name_if<T: Into<String>>(mut self, if_symbol: T, if_dll_name: T) -> Builder {
-        self.options.csharp_if_symbol = if_symbol.into();
-        self.options.csharp_if_dll_name = if_dll_name.into();
+        self.options.csharp_if_dll_imports.push((if_symbol.into(), if_dll_name.into()));
         self
     }
 

--- a/csbindgen/src/emitter.rs
+++ b/csbindgen/src/emitter.rs
@@ -90,26 +90,42 @@ pub fn emit_csharp(
     let method_prefix = &options.csharp_method_prefix;
     let accessibility = &options.csharp_class_accessibility;
 
-    let mut dll_name = match options.csharp_if_symbol.as_str() {
-        "" => format!(
+    let dll_name = if options.csharp_disable_emit_dll_name {
+        "".to_string()
+    } else if options.csharp_if_dll_imports.is_empty() {
+        format!(
             "        const string __DllName = \"{}\";",
             options.csharp_dll_name
-        ),
-        _ => {
-            format!(
-                "#if {0}
-        const string __DllName = \"{1}\";
-#else
-        const string __DllName = \"{2}\";
-#endif
-        ",
-                options.csharp_if_symbol, options.csharp_if_dll_name, options.csharp_dll_name
-            )
+        )
+    } else {
+        let mut s = String::new();
+        for (i, pair) in options.csharp_if_dll_imports.iter().enumerate() {
+            let (if_symbol, if_dll_name) = pair;
+            if i == 0 {
+                s.push_str(
+                    format!(
+                        "#if {if_symbol}\n        const string __DllName = \"{if_dll_name}\";\n"
+                    )
+                    .as_str(),
+                );
+            } else {
+                s.push_str(
+                    format!(
+                        "#elif {if_symbol}\n        const string __DllName = \"{if_dll_name}\";\n"
+                    )
+                    .as_str(),
+                );
+            }
         }
+        s.push_str(
+            format!(
+                "#else\n        const string __DllName = \"{}\";\n#endif\n        ",
+                options.csharp_dll_name
+            )
+            .as_str(),
+        );
+        s
     };
-    if options.csharp_disable_emit_dll_name {
-        dll_name = "".to_string();
-    }
 
     let mut method_list_string = String::new();
     let mut delegate_list = Vec::new();


### PR DESCRIPTION
This PR adds support for adding multiple conditions by chaining `csharp_dll_name_if()`.

This is useful when the internal names of distributed compiled binaries are different. I use this to generate SQLite bindings.

```rust
// ...

builder
  .csharp_dll_name_if("UNITY_IOS && !UNITY_EDITOR", "__Internal")
  .csharp_dll_name_if("UNITY_ANDROID && !UNITY_EDITOR", "sqliteX")
  .generate_csharp_file("../Sqlite3.Native/NativeMethods.g.cs")
  .unwrap();
```

```cs
// generated file

public static unsafe partial class NativeMethods
{
#if UNITY_IOS && !UNITY_EDITOR
    const string __DllName = "__Internal";
#elif UNITY_ANDROID && !UNITY_EDITOR
    const string __DllName = "sqliteX";
#else
    const string __DllName = "libsqlite3";
#endif
        
    // ...
}
```