### PR TITLE
ci: use Trusted Publishing

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -16,19 +16,13 @@ jobs:
   build-and-push-rust:
     permissions:
       contents: write
+      id-token: write # required for crates.io publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - name: Load secrets
-        id: op-load-secret
-        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PUBLIC }}
-          CARGO_REGISTRY_TOKEN: "op://${{ vars.OP_VAULT_ACTIONS_PUBLIC }}/CARGO_REGISTRY_TOKEN/credential"
-
       - uses: Cysharp/Actions/.github/actions/checkout@main
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
       - run: cargo build --verbose
       - run: cargo test update_package_version -- ${{ inputs.tag }} --nocapture
       - run: |
@@ -37,7 +31,7 @@ jobs:
           git commit -m "Update cargo.toml version to ${{ inputs.tag }}" -a
       - run: cargo publish --manifest-path csbindgen/Cargo.toml
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.op-load-secret.outputs.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - run: git tag ${{ inputs.tag }}
       - name: Push changes
         uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa


### PR DESCRIPTION
## Summary

Change crate.io publishing from API Token to Trusted Publishing.

see: https://crates.io/docs/trusted-publishing

Trusted Publishing is a much safer way to publish crates, and it also verifies that the crate was published from GitHub Actions rather than with an individual user token.