### PR TITLE
fix ByteBuffer example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,8 +1009,8 @@ impl ByteBuffer {
             vec![]
         } else {
             let element_size = std::mem::size_of::<T>() as i32;
-            let length = (self.length * element_size) as usize;
-            let capacity = (self.capacity * element_size) as usize;
+            let length = (self.length / element_size) as usize;
+            let capacity = (self.capacity / element_size) as usize;
 
             unsafe { Vec::from_raw_parts(self.ptr as *mut T, length, capacity) }
         }


### PR DESCRIPTION
in the example, the ByteBuffer tracks the length & capacity of the allocated vector in bytes.

in order to reproduce the original Vec of the correct size, the length in bytes should be divided by element_size