### PR TITLE
ci: use OIDC for NuGet package push authentication

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -30,4 +30,4 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: dotnet build -c Release
-      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts
+      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -o $GITHUB_WORKSPACE/artifacts

--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -29,4 +29,5 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      - run: dotnet build -c Debug
+      - run: dotnet build -c Release
+      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -61,9 +61,9 @@ jobs:
 
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      # pack nuget
+      # pack nuget (.nupkg and .symbols.nupkg will be created)
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
-      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
+      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -p:IncludeSymbols=true -o ./publish
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
@@ -76,10 +76,6 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
       - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
-        if: ${{ !inputs.dry-run }}
-        env:
-          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
         if: ${{ !inputs.dry-run }}
         env:
           NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -30,10 +30,12 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git commit -m "Update cargo.toml version to ${{ inputs.tag }}" -a
       - run: cargo publish --manifest-path csbindgen/Cargo.toml
+        if: ${{ !inputs.dry-run }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - run: git tag ${{ inputs.tag }}
       - name: Push changes
+        if: ${{ !inputs.dry-run }}
         uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -66,6 +66,16 @@ jobs:
           name: nuget
           path: ./publish
           retention-days: 1
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   create-release:
     needs: [build-dotnet, build-and-push-rust]
@@ -77,6 +87,6 @@ jobs:
       commit-id: ""
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
-      nuget-push: true
+      nuget-push: false
       release-upload: false
     secrets: inherit

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -44,6 +44,7 @@ jobs:
     needs: [build-and-push-rust]
     permissions:
       contents: read
+      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -50,15 +50,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - name: Load secrets
-        id: op-load-secret
-        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PUBLIC }}
-          NUGET_KEY: "op://${{ vars.OP_VAULT_ACTIONS_PUBLIC }}/NUGET_KEY/credential"
-
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       # pack nuget (.nupkg and .symbols.nupkg will be created)

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -79,6 +79,10 @@ jobs:
         if: ${{ !inputs.dry-run }}
         env:
           NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   create-release:
     needs: [build-dotnet, build-and-push-rust]

--- a/csbindgen/Cargo.toml
+++ b/csbindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csbindgen"
-version = "1.9.7"
+version = "1.9.8"
 edition = "2021"
 authors = ["Yoshifumi Kawai <ils@neue.cc>", "Cysharp, Inc."]
 description = "Generate C# FFI from Rust for automatically brings native code and C native library to .NET and Unity."


### PR DESCRIPTION
This updates the build-release workflow to leverage OpenID Connect (OIDC) for authenticating with NuGet.org. The package push operation is now performed directly within the build job, replacing static API key usage with ephemeral credentials for enhanced security.
