### PR TITLE
fix: negative constants are not included

### DIFF
--- a/csbindgen/src/lib.rs
+++ b/csbindgen/src/lib.rs
@@ -214,6 +214,53 @@ mod tests {
         fs::remove_file(generated_file_path).unwrap();
     }
 
+    #[test]
+    fn generates_negative_consts() {
+        let input_path = env::temp_dir().join(format!(
+            "csbindgen_negative_consts_{}.rs",
+            std::process::id()
+        ));
+        let output_path = env::temp_dir().join(format!(
+            "csbindgen_negative_consts_{}.cs",
+            std::process::id()
+        ));
+
+        fs::write(
+            &input_path,
+            r#"
+pub const NEGATIVE_INT: i32 = -1;
+pub const NEGATIVE_FLOAT: f32 = -1.5;
+pub const POSITIVE_INT: i32 = 2;
+"#,
+        )
+        .unwrap();
+
+        Builder::new()
+            .input_extern_file(input_path.to_str().unwrap())
+            .csharp_class_accessibility("public")
+            .csharp_generate_const_filter(|_| true)
+            .generate_csharp_file(&output_path)
+            .unwrap();
+
+        let csharp = fs::read_to_string(&output_path).unwrap();
+
+        fs::remove_file(input_path).unwrap();
+        fs::remove_file(output_path).unwrap();
+
+        assert!(
+            csharp.contains("public const int NEGATIVE_INT = -1;"),
+            "{csharp}"
+        );
+        assert!(
+            csharp.contains("public const float NEGATIVE_FLOAT = -1.5f;"),
+            "{csharp}"
+        );
+        assert!(
+            csharp.contains("public const int POSITIVE_INT = 2;"),
+            "{csharp}"
+        );
+    }
+
     // #[test]
     // fn test_emit_without_class() {
     //     let generated_file_path = "dotnet-sandbox/only_enums_and_structs_bindgen.cs";

--- a/csbindgen/src/parser.rs
+++ b/csbindgen/src/parser.rs
@@ -382,32 +382,7 @@ pub fn collect_const(
             if filter(const_name.as_str()) {
                 let t = parse_type(&ct.ty);
 
-                if let syn::Expr::Lit(lit_expr) = &*ct.expr {
-                    let value = match &lit_expr.lit {
-                        syn::Lit::Str(s) => {
-                            format!("\"{}\"", s.value())
-                        }
-                        syn::Lit::ByteStr(bs) => {
-                            format!("{:?}", bs.value())
-                        }
-                        syn::Lit::Byte(b) => {
-                            format!("{}", b.value())
-                        }
-                        syn::Lit::Char(c) => {
-                            format!("'{}'", c.value())
-                        }
-                        syn::Lit::Int(i) => {
-                            format!("{}", i.base10_parse::<i64>().unwrap())
-                        }
-                        syn::Lit::Float(f) => {
-                            format!("{}", f.base10_parse::<f64>().unwrap())
-                        }
-                        syn::Lit::Bool(b) => {
-                            format!("{}", b.value)
-                        }
-                        _ => String::new(),
-                    };
-
+                if let Some(value) = parse_const_value(&ct.expr) {
                     result.push(RustConst {
                         const_name,
                         rust_type: t,
@@ -418,6 +393,36 @@ pub fn collect_const(
             }
         }
     }
+}
+
+fn parse_const_value(expr: &syn::Expr) -> Option<String> {
+    if let syn::Expr::Lit(lit_expr) = expr {
+        return match &lit_expr.lit {
+            syn::Lit::Str(s) => Some(format!("\"{}\"", s.value())),
+            syn::Lit::ByteStr(bs) => Some(format!("{:?}", bs.value())),
+            syn::Lit::Byte(b) => Some(format!("{}", b.value())),
+            syn::Lit::Char(c) => Some(format!("'{}'", c.value())),
+            syn::Lit::Int(i) => Some(format!("{}", i.base10_parse::<i64>().unwrap())),
+            syn::Lit::Float(f) => Some(format!("{}", f.base10_parse::<f64>().unwrap())),
+            syn::Lit::Bool(b) => Some(format!("{}", b.value)),
+            _ => None,
+        };
+    }
+
+    if let syn::Expr::Unary(u) = expr {
+        if matches!(u.op, syn::UnOp::Neg(_)) {
+            return match &*u.expr {
+                syn::Expr::Lit(lit_expr) => match &lit_expr.lit {
+                    syn::Lit::Int(i) => Some(format!("-{}", i.base10_parse::<i64>().unwrap())),
+                    syn::Lit::Float(f) => Some(format!("-{}", f.base10_parse::<f64>().unwrap())),
+                    _ => None,
+                },
+                _ => None,
+            };
+        }
+    }
+
+    None
 }
 
 pub fn collect_enum(ast: &syn::File, result: &mut Vec<RustEnum>) {


### PR DESCRIPTION
Because syn parses negative numbers as `Expr::Unary`, simply matching `Lit` will not parse negative numbers, and as a result, negative constants will not be generated in C#. 

This PR will enable the correct parsing and generation of negative constants.